### PR TITLE
chore: ignore TS and ESLint errors during preview build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,21 @@
 /** @type {import('next').NextConfig} */
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
 const nextConfig = {
   output: 'export',
   images: { unoptimized: true },
   basePath,
   assetPrefix: basePath,
+
+  // ⬇️ Unblock build even if TypeScript has errors (temporary to preview the site)
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  // ⬇️ Don’t fail the build on ESLint warnings/errors
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
+
 module.exports = nextConfig;
 


### PR DESCRIPTION
## Summary
- ignore TypeScript and ESLint errors so `next build` won't block previews

## Testing
- `NEXT_TELEMETRY_DISABLED=1 npm run dev`
- `NEXT_TELEMETRY_DISABLED=1 npm run preview` *(fails: `next export has been removed in favor of 'output: export'`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab08b2e340833197284524459a5033