### PR TITLE
Render pages from HTML templates

### DIFF
--- a/app/en/head.tsx
+++ b/app/en/head.tsx
@@ -1,0 +1,2 @@
+import TemplateHead from '@/components/TemplateHead';
+export default function Head() { return <TemplateHead />; }

--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -1,8 +1,13 @@
+import TemplateScripts from '@/components/TemplateScripts';
+import { loadTemplateHtmlFromFile } from '@/lib/template';
+
 export default function HomeEN() {
+  // Na start używamy tej samej wersji index.html; później podmienimy na EN.
+  const html = loadTemplateHtmlFromFile('index');
   return (
-    <main style={{ padding: '2rem' }}>
-      <h1>KingPL (EN)</h1>
-      <p>Coming soon: integration from <code>template/</code>.</p>
-    </main>
+    <div>
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+      <TemplateScripts />
+    </div>
   );
 }

--- a/app/pl/head.tsx
+++ b/app/pl/head.tsx
@@ -1,0 +1,2 @@
+import TemplateHead from '@/components/TemplateHead';
+export default function Head() { return <TemplateHead />; }

--- a/app/pl/page.tsx
+++ b/app/pl/page.tsx
@@ -1,8 +1,12 @@
+import TemplateScripts from '@/components/TemplateScripts';
+import { loadTemplateHtmlFromFile } from '@/lib/template';
+
 export default function HomePL() {
+  const html = loadTemplateHtmlFromFile('index'); // template/file/index.html
   return (
-    <main style={{ padding: '2rem' }}>
-      <h1>KingPL (PL)</h1>
-      <p>Wkrótce: integracja z <code>template/</code>.</p>
-    </main>
+    <div>
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+      <TemplateScripts />
+    </div>
   );
 }

--- a/components/TemplateHead.tsx
+++ b/components/TemplateHead.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { publicPath } from '@/lib/publicPath';
+
+export default function TemplateHead() {
+  // Kolejność z <head> w template/file/index.html
+  const css = [
+    publicPath('/template/file/assets/css/bootstrap.min.css'),
+    publicPath('/template/file/assets/css/fontawesome.css'),
+    publicPath('/template/file/assets/css/magnific-popup.css'),
+    publicPath('/template/file/assets/css/nice-select.css'),
+    publicPath('/template/file/assets/css/slick-slider.css'),
+    publicPath('/template/file/assets/css/owl.carousel.min.css'),
+    publicPath('/template/file/assets/css/aos.css'),
+    // z index.html: zewnętrzny styl Swipera
+    'https://unpkg.com/swiper/swiper-bundle.min.css',
+    publicPath('/template/file/assets/css/mobile-menu.css'),
+    publicPath('/template/file/assets/css/main.css'),
+  ];
+
+  return (
+    <>
+      {css.map((href) => (
+        <link key={href} rel="stylesheet" href={href} />
+      ))}
+      <link rel="icon" href={publicPath('/template/file/assets/img/logo/titile1.png')} />
+      <title>KingPL</title>
+    </>
+  );
+}

--- a/components/TemplateScripts.tsx
+++ b/components/TemplateScripts.tsx
@@ -1,0 +1,40 @@
+'use client';
+import Script from 'next/script';
+import { publicPath } from '@/lib/publicPath';
+
+export default function TemplateScripts() {
+  // Kolejność z dołu index.html:
+  const js = [
+    publicPath('/template/file/assets/js/jquery-3-7-1.min.js'),
+    publicPath('/template/file/assets/js/bootstrap.min.js'),
+    publicPath('/template/file/assets/js/fontawesome.js'),
+    publicPath('/template/file/assets/js/mobile-menu.js'),
+    publicPath('/template/file/assets/js/jquery.magnific-popup.js'),
+    publicPath('/template/file/assets/js/owl.carousel.min.js'),
+    publicPath('/template/file/assets/js/jquery.countup.js'),
+    publicPath('/template/file/assets/js/slick-slider.js'),
+    publicPath('/template/file/assets/js/jquery.nice-select.js'),
+    publicPath('/template/file/assets/js/gsap.min.js'),
+    publicPath('/template/file/assets/js/apexcharts.js'),
+    publicPath('/template/file/assets/js/ScrollTrigger.min.js'),
+    publicPath('/template/file/assets/js/Splitetext.js'),
+    publicPath('/template/file/assets/js/text-animation.js'),
+    publicPath('/template/file/assets/js/switchmode.js'),
+    publicPath('/template/file/assets/js/aos.js'),
+    publicPath('/template/file/assets/js/SmoothScroll.js'),
+    publicPath('/template/file/assets/js/swiper.js'),
+    publicPath('/template/file/assets/js/jquery.lineProgressbar.js'),
+    publicPath('/template/file/assets/js/tilt.jquery.js'),
+    publicPath('/template/file/assets/js/chart.js'),
+    publicPath('/template/file/assets/js/animation.js'),
+    publicPath('/template/file/assets/js/main.js'),
+  ];
+
+  return (
+    <>
+      {js.map((src) => (
+        <Script key={src} src={src} strategy="afterInteractive" />
+      ))}
+    </>
+  );
+}

--- a/lib/publicPath.ts
+++ b/lib/publicPath.ts
@@ -1,0 +1,7 @@
+export function publicPath(p: string) {
+  const base = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  // Upewnij się, że p zaczyna się od "/"
+  const rel = p.startsWith('/') ? p : `/${p}`;
+  return `${base}${rel}`.replace(/\/+/g, '/');
+}
+

--- a/lib/template.ts
+++ b/lib/template.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+
+function extractBody(html: string): string {
+  const m = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  return m ? m[1] : html;
+}
+// usuń <script>…</script> z body, bo skrypty doładujemy osobno
+function stripScripts(html: string): string {
+  return html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+}
+function rewriteRelUrls(html: string): string {
+  const base = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const prefix = `${base}/template/file/`.replace(/\/+/g, '/');
+
+  // src="rel"
+  html = html.replace(/\bsrc\s*=\s*"(?!https?:|\/|data:|mailto:|tel:|#)([^"]+)"/gi,
+    (_m, p1) => `src="${prefix}${p1.replace(/^\.\/+/, '')}"`);
+  // href="rel"
+  html = html.replace(/\bhref\s*=\s*"(?!https?:|\/|data:|mailto:|tel:|#)([^"]+)"/gi,
+    (_m, p1) => `href="${prefix}${p1.replace(/^\.\/+/, '')}"`);
+  return html;
+}
+
+export function loadTemplateHtmlFromFile(slug: string): string {
+  const ROOT = process.cwd();
+  const file = path.join(ROOT, 'template', 'file', `${slug}.html`);
+  if (!fs.existsSync(file)) throw new Error(`Brak pliku: ${file}`);
+  const raw = fs.readFileSync(file, 'utf8');
+  const body = extractBody(raw);
+  return rewriteRelUrls(stripScripts(body));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mdx-js/mdx": "^3.0.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "fs-extra": "^11.2.0",
         "gray-matter": "^4.0.3",
         "next": "14.2.0",
         "next-mdx-remote": "^4.4.0",
@@ -5724,6 +5725,20 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -6400,6 +6415,18 @@
       "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
       "integrity": "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==",
       "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/keccak": {
       "version": "3.0.4",
@@ -13552,6 +13579,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "import:template": "node scripts/import-template.mjs",
+    "predev": "npm run import:template",
+    "prebuild": "npm run import:template",
     "dev": "next dev",
     "build": "next build",
     "export": "next export || true",
@@ -19,7 +22,8 @@
     "react-dom": "^18.2.0",
     "remark-gfm": "^3.0.1",
     "viem": "^2.7.0",
-    "wagmi": "^2.5.7"
+    "wagmi": "^2.5.7",
+    "fs-extra": "^11.2.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/scripts/import-template.mjs
+++ b/scripts/import-template.mjs
@@ -1,0 +1,16 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+const ROOT = process.cwd();
+const SRC  = path.join(ROOT, 'template');
+const DST  = path.join(ROOT, 'public', 'template');
+
+(async () => {
+  if (!(await fs.pathExists(SRC))) {
+    console.error(`❌ Folder ${SRC} nie istnieje. Dodaj pliki do 'template/'.`);
+    process.exit(1);
+  }
+  await fs.remove(DST);
+  await fs.copy(SRC, DST);
+  console.log(`✅ Skopiowano: ${path.relative(ROOT, SRC)} → ${path.relative(ROOT, DST)}`);
+})();


### PR DESCRIPTION
## Summary
- add publicPath helper and HTML template loader
- copy static template files before dev/build via import script
- render /pl and /en pages directly from template HTML with required CSS/JS

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `curl -I http://localhost:3000/pl`
- `curl -I http://localhost:3000/en`


------
https://chatgpt.com/codex/tasks/task_e_68ab6dd969548331896f58c9f38a3147