### PR TITLE
feat: dynamically load template scripts

### DIFF
--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -1,13 +1,13 @@
 import TemplateScripts from '@/components/TemplateScripts';
-import { loadTemplateHtmlFromFile } from '@/lib/template';
+import { loadTemplateFromFile } from '@/lib/template';
 
 export default function HomeEN() {
   // Na start używamy tej samej wersji index.html; później podmienimy na EN.
-  const html = loadTemplateHtmlFromFile('index');
+  const { html, scripts } = loadTemplateFromFile('index');
   return (
     <div>
       <div dangerouslySetInnerHTML={{ __html: html }} />
-      <TemplateScripts />
+      <TemplateScripts scripts={scripts} />
     </div>
   );
 }

--- a/app/pl/page.tsx
+++ b/app/pl/page.tsx
@@ -1,12 +1,12 @@
 import TemplateScripts from '@/components/TemplateScripts';
-import { loadTemplateHtmlFromFile } from '@/lib/template';
+import { loadTemplateFromFile } from '@/lib/template';
 
 export default function HomePL() {
-  const html = loadTemplateHtmlFromFile('index'); // template/file/index.html
+  const { html, scripts } = loadTemplateFromFile('index'); // template/file/index.html
   return (
     <div>
       <div dangerouslySetInnerHTML={{ __html: html }} />
-      <TemplateScripts />
+      <TemplateScripts scripts={scripts} />
     </div>
   );
 }

--- a/components/TemplateScripts.tsx
+++ b/components/TemplateScripts.tsx
@@ -1,38 +1,10 @@
 'use client';
 import Script from 'next/script';
-import { publicPath } from '@/lib/publicPath';
 
-export default function TemplateScripts() {
-  // Kolejność z dołu index.html:
-  const js = [
-    publicPath('/template/file/assets/js/jquery-3-7-1.min.js'),
-    publicPath('/template/file/assets/js/bootstrap.min.js'),
-    publicPath('/template/file/assets/js/fontawesome.js'),
-    publicPath('/template/file/assets/js/mobile-menu.js'),
-    publicPath('/template/file/assets/js/jquery.magnific-popup.js'),
-    publicPath('/template/file/assets/js/owl.carousel.min.js'),
-    publicPath('/template/file/assets/js/jquery.countup.js'),
-    publicPath('/template/file/assets/js/slick-slider.js'),
-    publicPath('/template/file/assets/js/jquery.nice-select.js'),
-    publicPath('/template/file/assets/js/gsap.min.js'),
-    publicPath('/template/file/assets/js/apexcharts.js'),
-    publicPath('/template/file/assets/js/ScrollTrigger.min.js'),
-    publicPath('/template/file/assets/js/Splitetext.js'),
-    publicPath('/template/file/assets/js/text-animation.js'),
-    publicPath('/template/file/assets/js/switchmode.js'),
-    publicPath('/template/file/assets/js/aos.js'),
-    publicPath('/template/file/assets/js/SmoothScroll.js'),
-    publicPath('/template/file/assets/js/swiper.js'),
-    publicPath('/template/file/assets/js/jquery.lineProgressbar.js'),
-    publicPath('/template/file/assets/js/tilt.jquery.js'),
-    publicPath('/template/file/assets/js/chart.js'),
-    publicPath('/template/file/assets/js/animation.js'),
-    publicPath('/template/file/assets/js/main.js'),
-  ];
-
+export default function TemplateScripts({ scripts }: { scripts: string[] }) {
   return (
     <>
-      {js.map((src) => (
+      {scripts.map((src) => (
         <Script key={src} src={src} strategy="afterInteractive" />
       ))}
     </>

--- a/lib/template.ts
+++ b/lib/template.ts
@@ -5,28 +5,50 @@ function extractBody(html: string): string {
   const m = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
   return m ? m[1] : html;
 }
-// usuń <script>…</script> z body, bo skrypty doładujemy osobno
-function stripScripts(html: string): string {
-  return html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+
+function rewriteRelUrl(url: string): string {
+  const base = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const prefix = `${base}/template/file/`.replace(/\/+/g, '/');
+  if (/^(?:https?:|\/|data:|mailto:|tel:|#)/i.test(url)) return url;
+  return `${prefix}${url.replace(/^\.\/+/, '')}`;
 }
+
+function stripScripts(html: string): { html: string; scripts: string[] } {
+  const scripts: string[] = [];
+  const without = html.replace(/<script\b[^>]*src=["']([^"']+)["'][^>]*><\/script>/gi,
+    (_m, src) => {
+      scripts.push(rewriteRelUrl(src));
+      return '';
+    });
+  return { html: without, scripts };
+}
+
 function rewriteRelUrls(html: string): string {
   const base = process.env.NEXT_PUBLIC_BASE_PATH || '';
   const prefix = `${base}/template/file/`.replace(/\/+/g, '/');
-
-  // src="rel"
   html = html.replace(/\bsrc\s*=\s*"(?!https?:|\/|data:|mailto:|tel:|#)([^"]+)"/gi,
     (_m, p1) => `src="${prefix}${p1.replace(/^\.\/+/, '')}"`);
-  // href="rel"
   html = html.replace(/\bhref\s*=\s*"(?!https?:|\/|data:|mailto:|tel:|#)([^"]+)"/gi,
     (_m, p1) => `href="${prefix}${p1.replace(/^\.\/+/, '')}"`);
   return html;
 }
 
-export function loadTemplateHtmlFromFile(slug: string): string {
+export interface TemplateData {
+  html: string;
+  scripts: string[];
+}
+
+export function loadTemplateFromFile(slug: string): TemplateData {
   const ROOT = process.cwd();
   const file = path.join(ROOT, 'template', 'file', `${slug}.html`);
   if (!fs.existsSync(file)) throw new Error(`Brak pliku: ${file}`);
   const raw = fs.readFileSync(file, 'utf8');
-  const body = extractBody(raw);
-  return rewriteRelUrls(stripScripts(body));
+  const { html: noScripts, scripts } = stripScripts(raw);
+  const body = extractBody(noScripts);
+  return { html: rewriteRelUrls(body), scripts };
+}
+
+// Zachowaj starą nazwę dla zgodności, zwraca tylko HTML.
+export function loadTemplateHtmlFromFile(slug: string): string {
+  return loadTemplateFromFile(slug).html;
 }


### PR DESCRIPTION
## Summary
- parse template HTML to extract script tags and rewrite relative URLs
- load template scripts via props instead of hardcoded list
- update locale pages to use the new dynamic loader

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab715cc9708331a0e203de910bffdd